### PR TITLE
Add computed styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,63 @@ You can define constants in your global or namespaced styles that will be availa
 
 There are plenty more things you can do with useStyles, learn more in [User Guide](USER_GUIDE.md)
 
+### Computed and Dynamic styles
+
+#### Computed styles:
+```js
+import useStyles from './my-namespaced-styles';
+
+const component = () ⇒ {
+  const isPurple = useState(true);
+  const s = useStyles([isPurple]);
+
+  return (
+    <Text styles={s`fx:1 &purple`}>
+      Hello World!
+    </Text>
+  );
+}
+```
+
+Computed styles are prefixed with the `&` character. Note that we are passing isPurple as a hook's dependency to track it changes. We can then use this dependency in our computed styles as following.
+
+```js
+import { Styles } from 'react-native-use-styles';
+
+export default Styles({
+  computed: {
+    purple: ([isPurple]) => ({ color: isPurple ? 'purple' : 'black' });
+  }
+});
+```
+If the dependencies change, only styles with a computed in it will be recomputed.
+
+#### Dynamic styles:
+```js
+import useStyles from './my-namespaced-styles';
+
+const component = () ⇒ {
+  const isPurple = useState(true);
+  const s = useStyles();
+
+  return (
+    <Text styles={s`fx:1 ${isPurple && '.purple'}`}>
+      Hello World!
+    </Text>
+  );
+}
+```
+
+And a simple style definition as following:
+
+```js
+import { Styles } from 'react-native-use-styles';
+
+export default Styles({
+  purple: { color: 'purple' }
+});
+```
+
 ### Definition order
 
 You want your global styles to be defined or imported before all the other styles. So just import your global styles at the top of your `App.js` or your main entry point; before the imports of your custom or navigation component.
@@ -135,24 +192,11 @@ This library was created with performance in mind; useStyles has multiple cache 
 We plan to keep working in the library to optimize and add new features (contributions are welcome):
 
 - Add informative errors
-- Improve dynamic styling
 - Add tests with test renderers
 - Add tests to a pre-push hook
 - Benchmark
 - Make library definition order safe (?)
 - Add Components with className (?)
-```js
-import namespace from './my-namespaced-styles';
-const { Text } = namespace;
-
-const component = () ⇒ {
-  return (
-    <Text className=".global-style .local-style">
-      Hello World!
-    </Text>
-  );
-}
-```
 
 If you have an idea that could make this library better we would love to hear it. Please take a look at our [Contributing Guidelines](CONTRIBUTING.md) to get to know the rules and how to get started with your contribution.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -32,8 +32,38 @@ export default Styles({
 });
 ```
 
-### Dynamic styling
+### Computed and Dynamic styles
 
+#### Computed styles:
+```js
+import useStyles from './my-namespaced-styles';
+
+const component = () ⇒ {
+  const isPurple = useState(true);
+  const s = useStyles([isPurple]);
+
+  return (
+    <Text styles={s`fx:1 &purple`}>
+      Hello World!
+    </Text>
+  );
+}
+```
+
+Computed styles are prefixed with the `&` character. Note that we are passing isPurple as a hook's dependency to track it changes. We can then use this dependency in our computed styles as following.
+
+```js
+import { Styles } from 'react-native-use-styles';
+
+export default Styles({
+  computed: {
+    purple: ([isPurple]) => ({ color: isPurple ? 'purple' : 'black' });
+  }
+});
+```
+If the dependencies change, only styles with a computed in it will be recomputed.
+
+#### Dynamic styles:
 ```js
 import useStyles from './my-namespaced-styles';
 
@@ -42,14 +72,22 @@ const component = () ⇒ {
   const s = useStyles();
 
   return (
-    <Text styles={s`fx:1 ${isPurple && 'color:purple'}`}>
+    <Text styles={s`fx:1 ${isPurple && '.purple'}`}>
       Hello World!
     </Text>
   );
 }
 ```
 
-This is an example of how you would add conditionals to your styles.
+And a simple styles definition as following:
+
+```js
+import { Styles } from 'react-native-use-styles';
+
+export default Styles({
+  purple: { color: 'purple' }
+});
+```
 
 ### Styles namespace name
 

--- a/demo/App.js
+++ b/demo/App.js
@@ -1,15 +1,17 @@
 import './styles/global';
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, Button } from 'react-native';
 
 import useStyles from './styles/namespaced';
 
 export default function App() {
-  const s = useStyles();
+  const [isDisabled, setDisabled] = useState(false);
+  const s = useStyles([isDisabled]);
 
   return (
-    <View style={[s`.container`]}>
-      <Text style={s`.text`}>Hello Planet!</Text>
+    <View style={s`.container`}>
+      <Text style={s`.centered font:size:$title &disabled`}>Hello Planet!</Text>
+      <Button onPress={() => setDisabled(current => !current)} title="toggle" />
     </View>
   );
 }

--- a/demo/styles/global.js
+++ b/demo/styles/global.js
@@ -4,6 +4,7 @@ GlobalStyles({
   constants: {
     midnight: '#2c3e50',
     clouds: '#ecf0f1',
+    disabled: '#7f7f7f',
     title: 40
   },
   container: "bg:color:$midnight fx:1 jf:content:center",

--- a/demo/styles/namespaced.js
+++ b/demo/styles/namespaced.js
@@ -1,5 +1,8 @@
 import { Styles } from "react-native-use-styles";
 
 export default Styles({
-  text: "color:$clouds font:size:$title txt:align:center"
+  computed: {
+    disabled: ([isDisabled]) => `color:${isDisabled ? '$disabled' : '$clouds'}`
+  },
+  centered: "txt:align:center"
 });

--- a/src/core/stylesManager.js
+++ b/src/core/stylesManager.js
@@ -1,10 +1,12 @@
 // TODO: p(124235, 'fl-row') to send the identifier of a Stylesheet.create style
-import { useMemo, useCallback } from "react";
+import { useRef } from "react";
 import transform from "./pathTransform";
 import { getFromCache, setInCache } from "./globalCache";
 import {
   isFalseyString,
   isClassName,
+  isComputed,
+  hasComputed,
   getKey,
   isNamespace,
   getKeyFromNamespace,
@@ -13,11 +15,35 @@ import {
   getPathFromLiteralTag
 } from "./utils";
 
-export const getFromDefinitionOrCache = (
+const recomputeMutation = (cache, dependencies) => {
+  for (let [key, { compute }] of Object.entries(cache)) {
+    if (hasComputed(key)) {
+      cache[key] = { 
+        compute, 
+        style: compute(dependencies) 
+      }
+    }
+  }
+};
+
+const computePath = (path, namespace, dependencies) => {
+  let fn = getFromStorage(path, namespace, null, false, true);
+  if (!fn) {
+    console.warn(`Computed ${path} not found in cache`);
+    return;
+  }
+
+  const computedStyle = fn(dependencies);
+  fn = GlobalUse(computedStyle, namespace);
+  return fn(dependencies);
+};
+
+export const getFromStorage = (
   pKey,
   namespace,
   definition,
-  isConstant = false
+  isConstant = false,
+  isComputed = false
 ) => {
   let space = namespace;
   let key = pKey;
@@ -28,53 +54,75 @@ export const getFromDefinitionOrCache = (
   }
   key = getKey(key);
 
-  return getFromCache(key, space, definition, isConstant);
+  return getFromCache(key, space, definition, isConstant, isComputed);
 };
 
 export const GlobalUse = (path, namespace) => {
-  const styles = path
-    .trim()
-    .split(" ")
-    .reduce((stylesAcc, p) => {
-      let style;
+  // TODO: this is retrieving all the styles even if we are recomputing
+  // maybe, if we are recomputing, we should find a way to retreive only the computeds
+  return dependencies => {
+    let styles = path;
 
-      if (isFalseyString(p)) {
-        return stylesAcc;
-      }
+    if (typeof styles !== "object") {
+      styles = path
+        .trim()
+        .split(" ")
+        .reduce((stylesAcc, p) => {
+          let style;
 
-      if (isClassName(p)) {
-        style = getFromDefinitionOrCache(p, namespace);
-      } else {
-        style = transform(p, key =>
-          getFromDefinitionOrCache(key, namespace, null, true)
-        );
-      }
-      return { ...stylesAcc, ...style };
-    }, {});
-  return styles;
-};
+          if (isFalseyString(p)) {
+            return stylesAcc;
+          }
 
-export const useGlobalStyles = nameSpace => {
-  // create local cache for returned arrays, so we can avoid re-renders and re-transformations
-  const localCache = useMemo(() => Object.create(null), []);
+          if (isClassName(p)) {
+            style = getFromStorage(p, namespace);
+          } else if (isComputed(p)) {
+            style = computePath(p, namespace, dependencies);
+          } else {
+            style = transform(p, key =>
+              getFromStorage(key, namespace, null, true)
+            );
+          }
 
-  return useCallback((strings, ...expressions) => {
-    const path = getPathFromLiteralTag(strings, expressions);
-
-    if (localCache[path]) {
-      return localCache[path];
+          return { ...stylesAcc, ...style };
+        }, {});
     }
 
-    const styles = GlobalUse(path, nameSpace);
-    Object.assign(localCache, { [path]: styles });
-
     return styles;
-  }, []);
+  };
+};
+
+export const useGlobalStyles = (nameSpace, dependencies = []) => {
+  // create local cache for returned styles, so we can avoid re renders, transformations and computations
+  const lastDependencies = useRef(dependencies);
+  const localCache = useRef(Object.create(null));
+  const cache = localCache.current;
+
+  // manual shallow compare; not using useEffect because it would need to render twice
+  // given the necessity of explicitly telling react to queue an update with set[State]
+  // after recomputing styles
+  if (lastDependencies.current.some((dep, index) => dep !== dependencies[index])) {
+    recomputeMutation(cache, dependencies)
+    lastDependencies.current = dependencies;
+  }
+
+  return (strings, ...expressions) => {
+    const path = getPathFromLiteralTag(strings, expressions);
+
+    if (cache[path]) {
+      return cache[path].style;
+    }
+
+    const compute = GlobalUse(path, nameSpace);
+    const style = compute(dependencies);
+    Object.assign(cache, { [path]: { style, compute } });
+    return style;
+  };
 };
 
 export const GlobalStyles = (definition, namespace) => {
   for (let [key, value] of Object.entries(definition)) {
-    // only transform if it's not a style object
+    // transform if it's not a style object, the constants object or the computeds object
     if (typeof value !== "object") {
       const styles = value
         .trim()
@@ -87,10 +135,10 @@ export const GlobalStyles = (definition, namespace) => {
           }
 
           if (isClassName(path)) {
-            style = getFromDefinitionOrCache(path, namespace, definition);
+            style = getFromStorage(path, namespace, definition);
           } else {
             style = transform(path, key =>
-              getFromDefinitionOrCache(key, namespace, definition, true)
+              getFromStorage(key, namespace, definition, true)
             );
           }
 
@@ -114,8 +162,8 @@ export const Styles = (definition, namespace) => {
 
   GlobalStyles(definition, definitionNamespace);
 
-  const useStyles = () => useGlobalStyles(definitionNamespace);
+  const useStyles = dependencies =>
+    useGlobalStyles(definitionNamespace, dependencies);
   useStyles.namespace = definitionNamespace;
-
   return useStyles;
 };

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -1,7 +1,10 @@
 const CLASS_PREFIX = ".";
 const NAMESPACE_PREFIX = "@";
 const CONSTANTS_PREFIX = "$";
-const NAMESPACE_REGEX = new RegExp(`@[^${CLASS_PREFIX}${CONSTANTS_PREFIX}]+`);
+const COMPTUED_PREFIX = "&";
+const NAMESPACE_REGEX = new RegExp(
+  `@[^${CLASS_PREFIX}${CONSTANTS_PREFIX}${COMPTUED_PREFIX}]+`
+);
 
 export const isNamespace = path => path.startsWith(NAMESPACE_PREFIX);
 
@@ -16,6 +19,11 @@ export const isClassName = path =>
 
 export const isConstant = path =>
   getKeyFromNamespace(path).startsWith(CONSTANTS_PREFIX);
+
+export const isComputed = path =>
+  getKeyFromNamespace(path).startsWith(COMPTUED_PREFIX);
+
+export const hasComputed = path => path.indexOf(COMPTUED_PREFIX) !== -1;
 
 export const StyleSheetNoop = {
   flatten: styles => styles,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,18 +2,34 @@ type StyleObject = {
   [key: string]: unknown;
 };
 
+type Computed = (
+  dependencies: Array<any>
+) => StyleObject;
+
 export function setSeparator(sp: string): void;
 
-export function GlobalUse(path: string, namespace: string): StyleObject;
+export function GlobalUse(
+  path: string, 
+  namespace: string
+): Computed;
 
-export function useGlobalStyles(nameSpace: string): (strings: string[], expressions: string[]) => StyleObject;
+export function useGlobalStyles(
+  nameSpace: string, 
+  dependencies: Array<any>
+): (
+  strings: string[], 
+  expressions: string[]
+) => StyleObject;
 
 export function GlobalStyles(
   definition: StyleObject,
   namespace: string
 ): void;
 
-export function Styles(definition: StyleObject, namespace: string): {
+export function Styles(
+  definition: StyleObject, 
+  namespace: string
+): {
   (): () => typeof useGlobalStyles;
   namespace: string;
 };

--- a/tests/core/pathTransform.spec.js
+++ b/tests/core/pathTransform.spec.js
@@ -1,6 +1,6 @@
 import transform from "../../src/core/pathTransform";
 import { setInCache, clearCache } from "../../src/core/globalCache";
-import { getFromDefinitionOrCache } from "../../src/core/stylesManager";
+import { getFromStorage } from "../../src/core/stylesManager";
 
 describe("utils", () => {
   it("transforms key:value path", async () => {
@@ -57,9 +57,7 @@ describe("utils", () => {
       }
     });
     expect(
-      transform("color:$purple", key =>
-        getFromDefinitionOrCache(key, null, null, true)
-      )
+      transform("color:$purple", key => getFromStorage(key, null, null, true))
     ).toMatchObject({
       color: "purple"
     });
@@ -77,7 +75,7 @@ describe("utils", () => {
     );
     expect(
       transform("color:@namespace$purple", key =>
-        getFromDefinitionOrCache(key, "namespace", null, true)
+        getFromStorage(key, "namespace", null, true)
       )
     ).toMatchObject({
       color: "purple"

--- a/tests/core/stylesManager.spec.js
+++ b/tests/core/stylesManager.spec.js
@@ -2,6 +2,10 @@ import { clearCache, getFromCache } from "../../src/core/globalCache";
 import { GlobalStyles, Styles, GlobalUse } from "../../src/core/stylesManager";
 
 describe("utils", () => {
+  beforeAll(() => {
+    console.warn = () => {};
+  });
+
   beforeEach(() => {
     clearCache();
   });
@@ -65,7 +69,7 @@ describe("utils", () => {
     GlobalStyles({
       global: { flex: 1 }
     });
-    expect(GlobalUse(".global")).toMatchObject({ flex: 1 });
+    expect(GlobalUse(".global")()).toMatchObject({ flex: 1 });
   });
 
   it("GlobalUse gets local cache properly", async () => {
@@ -75,11 +79,11 @@ describe("utils", () => {
       },
       "namespace"
     );
-    expect(GlobalUse(".local", "namespace")).toMatchObject({ flex: 1 });
+    expect(GlobalUse(".local", "namespace")()).toMatchObject({ flex: 1 });
   });
 
   it("GlobalUse generates path styles properly", async () => {
-    expect(GlobalUse("max:height:300")).toMatchObject({ maxHeight: 300 });
+    expect(GlobalUse("max:height:300")()).toMatchObject({ maxHeight: 300 });
   });
 
   it("GlobalUse gets style from definition properly", async () => {
@@ -90,7 +94,7 @@ describe("utils", () => {
       },
       "namespace"
     );
-    expect(GlobalUse(".reused", "namespace")).toMatchObject({
+    expect(GlobalUse(".reused", "namespace")()).toMatchObject({
       color: "blue"
     });
   });
@@ -105,7 +109,7 @@ describe("utils", () => {
       },
       "namespace"
     );
-    expect(GlobalUse(".local", "namespace")).toMatchObject({
+    expect(GlobalUse(".local", "namespace")()).toMatchObject({
       color: "blue"
     });
   });
@@ -116,7 +120,7 @@ describe("utils", () => {
         blue: "blue"
       }
     });
-    expect(GlobalUse("color:$blue")).toMatchObject({
+    expect(GlobalUse("color:$blue")()).toMatchObject({
       color: "blue"
     });
   });
@@ -127,7 +131,7 @@ describe("utils", () => {
         blue: "blue"
       }
     });
-    expect(GlobalUse("color:$blue", "namespace")).toMatchObject({
+    expect(GlobalUse("color:$blue", "namespace")()).toMatchObject({
       color: "blue"
     });
   });
@@ -145,7 +149,7 @@ describe("utils", () => {
       },
       "namespace"
     );
-    expect(GlobalUse(".namespaced", "namespace")).toMatchObject({
+    expect(GlobalUse(".namespaced", "namespace")()).toMatchObject({
       color: "blue"
     });
   });
@@ -159,7 +163,7 @@ describe("utils", () => {
       },
       "namespace"
     );
-    expect(GlobalUse("color:$blue", "namespace")).toMatchObject({
+    expect(GlobalUse("color:$blue", "namespace")()).toMatchObject({
       color: "blue"
     });
   });
@@ -173,30 +177,72 @@ describe("utils", () => {
       },
       "namespace"
     );
-    expect(GlobalUse("color:@namespace$blue", "namespace")).toMatchObject({
+    expect(GlobalUse("color:@namespace$blue")()).toMatchObject({
       color: "blue"
     });
   });
 
   it("GlobalUse with falsey value false", async () => {
-    expect(GlobalUse("color:red false")).toMatchObject({
+    expect(GlobalUse("color:red false")()).toMatchObject({
       color: "red"
     });
   });
 
   it("GlobalUse with falsey value undefined", async () => {
-    expect(GlobalUse("color:red undefined")).toMatchObject({
+    expect(GlobalUse("color:red undefined")()).toMatchObject({
       color: "red"
     });
   });
 
   it("GlobalUse with only falsey value undefined", async () => {
-    expect(GlobalUse("color:red null")).toMatchObject({
+    expect(GlobalUse("color:red null")()).toMatchObject({
       color: "red"
     });
   });
 
   it("GlobalUse with only falsey value", async () => {
-    expect(GlobalUse("undefined")).toMatchObject({});
+    expect(GlobalUse("undefined")()).toMatchObject({});
+  });
+
+  it("GlobalUse with computed values", async () => {
+    Styles(
+      {
+        computed: {
+          disable: ([isDisabled]) => ({ color: isDisabled ? "grey" : "blue" })
+        }
+      },
+      "namespace"
+    );
+    expect(GlobalUse("&disable", "namespace")([true])).toMatchObject({
+      color: "grey"
+    });
+  });
+
+  it("GlobalUse with computed don't find value", async () => {
+    Styles(
+      {
+        computed: {
+          notDisable: ([isDisabled]) => ({
+            color: isDisabled ? "grey" : "blue"
+          })
+        }
+      },
+      "namespace"
+    );
+    expect(GlobalUse("&disable", "namespace")([true])).toMatchObject({});
+  });
+
+  it("GlobalUse with computed values in namespace", async () => {
+    Styles(
+      {
+        computed: {
+          disable: ([isDisabled]) => ({ color: isDisabled ? "grey" : "blue" })
+        }
+      },
+      "namespace"
+    );
+    expect(GlobalUse("@namespace&disable")([false])).toMatchObject({
+      color: "blue"
+    });
   });
 });

--- a/tests/core/utils.spec.js
+++ b/tests/core/utils.spec.js
@@ -6,10 +6,32 @@ import {
   isFalseyString,
   flattenStyles,
   getPathFromLiteralTag,
-  isConstant
+  isConstant,
+  isComputed,
+  hasComputed
 } from "../../src/core/utils";
 
 describe("utils", () => {
+  it("isComputed finds the computed", async () => {
+    expect(isComputed("&computed")).toBe(true);
+  });
+
+  it("isComputed finds the computed when is namespaced", async () => {
+    expect(isComputed("@namespace&isComputed")).toBe(true);
+  });
+
+  it("isComputed doesn't find the computed", async () => {
+    expect(isComputed("fx:dir:row")).toBe(false);
+  });
+
+  it("hasComputed finds the computed", async () => {
+    expect(hasComputed(".classname &computed")).toBe(true);
+  });
+
+  it("hasComputed doesn't find the computed", async () => {
+    expect(hasComputed("fx:dir:row")).toBe(false);
+  });
+
   it("isClassName finds the class", async () => {
     expect(isClassName(".classname")).toBe(true);
   });


### PR DESCRIPTION
This is a proof of concept to generate computed styles. This changes a little bit the API, but I think it could be a great addition. 

The general idea is to have the ability to recompute some styles that depends on some dependencies.

Example of usage, note that computed styles are accessed with the `&` prefix: 

```
import { Styles } from 'react-native-use-styles';

export default Styles({
  computed: {
    disabled: ([isDisabled]) => ({ color: isDisabled ? '$grey' : '$blue' })
  },
  local: '.container bg:color:green'
});
```

```
import { useState } from 'react';
import useStyles from './styles';

export default () => {
  const [isDisabled, setDisabled] = useState(true);
  const s = useStyles([isDisabled]);
  
  return (
    <View style={s`.local`}>
      <Text style={s`&disabled`}>Hello World!</Text>
      <Button onCLick={() => setDisabled(current => !current)} title="Toggle Disable" />
    </View>
  );
};
```

*This implementation recomputes only the styles with a `&` in it when dependencies change; not all the styles in the component.